### PR TITLE
Fix numba.jitclass deprecation warning

### DIFF
--- a/src/approximate_dictionary/core.py
+++ b/src/approximate_dictionary/core.py
@@ -54,7 +54,7 @@ def create_trie_from_state(edge_ptr, edges, children, records, depth):
     return Trie(edge_ptr, edges, children, numba_records, depth)
 
 
-@numba.jitclass([
+@numba.experimental.jitclass([
     ('edge_ptr', numba.int32[:]),
     ('edges', numba.int32[:]),
     ('children', numba.int32[:]),

--- a/src/approximate_dictionary/nfa.py
+++ b/src/approximate_dictionary/nfa.py
@@ -30,7 +30,7 @@ def initialize_nfa(k):
     return res
 
 
-@numba.jitclass([
+@numba.experimental.jitclass([
     ('bitmaps', numba.types.DictType(numba.int32, numba.int64)),
     ('state', numba.int64[:, :]),
     ('first_active', numba.int64[:]),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Unit tests for approximate_dictionary."""


### PR DESCRIPTION
* Replace `numba.jitclass` decorator with `numba.experimental.jitclass`
* Remove `__init__.py` from tests/